### PR TITLE
fix issue with keepNewLines for children with html nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ class Foo extends Component {
 | onClick | Function | | Function executed on click on 'Show more' or 'Show less' | `onClick={this.executeOnClick}`
 | expanded | boolean | 'false' | Control the text to be shown as expanded | `expanded={true}`
 | width | number | `0` | If not `0`, the calculation of the content will be based on this number. | |
-| keepNewLines | boolean | 'true' | Controls the new lines in text to be keept or not. If the new lines should be keept, you need to pass the text as Template literal [more info](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals). | `keepNewLines={true}`
+| keepNewLines | boolean | 'false' | Controls the new lines in text to be kept or not. When set to true, only strings can be passed in as children, and not html nodes. | `keepNewLines={true}`
 
 ## Developing
 Install development dependencies

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:akiratee/react-show-more-text.git"
+    "url": "git@github.com:devzonetech/react-show-more-text.git"
   },
   "homepage": "https://github.com/devzonetech/react-show-more-text",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:devzonetech/react-show-more-text.git"
+    "url": "git@github.com:akiratee/react-show-more-text.git"
   },
   "homepage": "https://github.com/devzonetech/react-show-more-text",
   "keywords": [

--- a/src/ShowMoreText.js
+++ b/src/ShowMoreText.js
@@ -11,7 +11,7 @@ class ShowMoreText extends Component {
         onClick: undefined,
         expanded: false,
         width: 0,
-        keepNewLines: true
+        keepNewLines: false
     };
 
     static propTypes = {

--- a/src/ShowMoreText.js
+++ b/src/ShowMoreText.js
@@ -15,7 +15,7 @@ class ShowMoreText extends Component {
     };
 
     static propTypes = {
-        children: PropTypes.string,
+        children: PropTypes.node,
         lines: PropTypes.number,
         more: PropTypes.node,
         less: PropTypes.node,


### PR DESCRIPTION
most recent changes introduced a bug where a TypeError will occur if html nodes are passed in when keepNewLines is true.
Reference: #8 

Solution:
- set keepNewLines to false
- set propType default back to 'node'
- update documentation to warn about limitation of keepNewLines functionality