### PR TITLE
Added event transfer to onClick callback

### DIFF
--- a/src/ShowMoreText.js
+++ b/src/ShowMoreText.js
@@ -75,7 +75,7 @@ class ShowMoreText extends Component {
                 },
                 () => {
                     if (_self.props.onClick) {
-                        _self.props.onClick(_self.state.expanded);
+                        _self.props.onClick(_self.state.expanded, event);
                     }
                 }
             );


### PR DESCRIPTION
Click event can be useful in some cases.
Here is an example of such a case.

https://codesandbox.io/s/affectionate-galois-x29zc?file=/src/App.tsx

If the event was passed, the `event.stopPropaganation()` method could be called.

Example:

```jsx
<ShowMoreText
  lines={3}
  more="Show more"
  less="Show less"
  onClick={(expanded, event) => {
    event.stopPropagation();
  }}
>
  Text
</ShowMoreText>
```

This would prevent the onClick event from triggering on the parent elements.